### PR TITLE
Added field to support the de centralised identity verification

### DIFF
--- a/schema/1.0/schema.json
+++ b/schema/1.0/schema.json
@@ -49,12 +49,12 @@
                   "DNS-TXT"
                 ]
               },
-              "source": {
+              "location": {
                 "type": "string",
                 "description": "Url of the website referencing to document store"
               }
             },
-            "required": ["type", "source"]
+            "required": ["type", "location"]
           }
         },
         "required": ["name", "documentStore"],

--- a/schema/1.0/schema.json
+++ b/schema/1.0/schema.json
@@ -39,6 +39,23 @@
             "type": "string",
             "pattern": "^0x[a-fA-F0-9]{40}$",
             "description": "Smart contract address of document store"
+          },
+          "identity": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "DNS",
+                  "REGISTRY"
+                ]
+              },
+              "source": {
+                "type": "string",
+                "description": "Url of the website referencing to document store"
+              }
+            },
+            "required": ["type", "source"]
           }
         },
         "required": ["name", "documentStore"],

--- a/schema/1.0/schema.json
+++ b/schema/1.0/schema.json
@@ -40,14 +40,13 @@
             "pattern": "^0x[a-fA-F0-9]{40}$",
             "description": "Smart contract address of document store"
           },
-          "identity": {
+          "identityProof": {
             "type": "object",
             "properties": {
               "type": {
                 "type": "string",
                 "enum": [
-                  "DNS",
-                  "REGISTRY"
+                  "DNS-TXT"
                 ]
               },
               "source": {

--- a/schema/1.0/schema.test.ts
+++ b/schema/1.0/schema.test.ts
@@ -29,7 +29,7 @@ describe("schema/v1.0", () => {
     }).toThrow("Invalid document");
   });
 
-  it("should be invalid if identity type is other than DNS and REGISTRY", () => {
+  it("should be valid if identity type is DNS or REGISTRY", () => {
     const document = merge(sample, {
       issuers: [
         {

--- a/schema/1.0/schema.test.ts
+++ b/schema/1.0/schema.test.ts
@@ -1,4 +1,4 @@
-import { omit } from "lodash";
+import { omit, merge } from "lodash";
 
 import { issueDocument, validateSchema } from "@govtechsg/open-attestation";
 
@@ -11,6 +11,37 @@ describe("schema/v1.0", () => {
     const valid = validateSchema(issuedDocument);
 
     expect(valid).toBe(true);
+  });
+
+  it("should be invalid if identity type is other than DNS and REGISTRY", () => {
+    const document = merge(sample, {
+      issuers: [
+        {
+          identity: {
+            type: "ABC",
+            source: "http:abc.com"
+          }
+        }
+      ]
+    });
+    expect(() => {
+      issueDocument(document, schema);
+    }).toThrow("Invalid document");
+  });
+
+  it("should be invalid if identity type is other than DNS and REGISTRY", () => {
+    const document = merge(sample, {
+      issuers: [
+        {
+          identity: {
+            type: "DNS",
+            source: "http:abc.com"
+          }
+        }
+      ]
+    });
+    const issuedDocument = issueDocument(document, schema);
+    expect(validateSchema(issuedDocument)).toBe(true);
   });
 
   it("should be valid with additonal key:value", () => {

--- a/schema/1.0/schema.test.ts
+++ b/schema/1.0/schema.test.ts
@@ -19,7 +19,7 @@ describe("schema/v1.0", () => {
         {
           identityProof: {
             type: "ABC",
-            source: "http:abc.com"
+            location: "http:abc.com"
           }
         }
       ]
@@ -35,7 +35,7 @@ describe("schema/v1.0", () => {
         {
           identityProof: {
             type: "DNS-TXT",
-            source: "http:abc.com"
+            location: "http:abc.com"
           }
         }
       ]

--- a/schema/1.0/schema.test.ts
+++ b/schema/1.0/schema.test.ts
@@ -13,11 +13,11 @@ describe("schema/v1.0", () => {
     expect(valid).toBe(true);
   });
 
-  it("should be invalid if identity type is other than DNS and REGISTRY", () => {
+  it("should be invalid if identity type is other than DNS-TXT", () => {
     const document = merge(sample, {
       issuers: [
         {
-          identity: {
+          identityProof: {
             type: "ABC",
             source: "http:abc.com"
           }
@@ -29,12 +29,12 @@ describe("schema/v1.0", () => {
     }).toThrow("Invalid document");
   });
 
-  it("should be valid if identity type is DNS or REGISTRY", () => {
+  it("should be valid if identity type is DNS-TXT", () => {
     const document = merge(sample, {
       issuers: [
         {
-          identity: {
-            type: "DNS",
+          identityProof: {
+            type: "DNS-TXT",
             source: "http:abc.com"
           }
         }


### PR DESCRIPTION
- added {identity: {type: "DNS", source: "abc.com"}}
- put enum in type to ["DNS", "REGISTRY"]